### PR TITLE
Bugfix: Add missing dependency

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -12,10 +12,11 @@ class support_sysstat::install {
 
   if $facts['os']['family'] == 'Debian' {
     file_line {'enable_sa2':
-      ensure => 'present',
-      path   => '/etc/default/sysstat',
-      line   => 'ENABLED="true"',
-      match  => '^ENABLED\=\"false\"'
+      ensure  => 'present',
+      path    => '/etc/default/sysstat',
+      line    => 'ENABLED="true"',
+      match   => '^ENABLED\=\"false\"',
+      require => Package['sysstat'],
     }
   }
 }


### PR DESCRIPTION
This commit adds a missing dependency between the `Package` and `file_line` resource.
The code crashes with the following error without this dependency:

```
Error: /Stage[main]/Main/File_line[enable_sa2]: Could not evaluate: No such file or directory @ rb_sysopen - /etc/default/sysstat
```